### PR TITLE
Removed spurious runDate argument to .makeExprMat in miRNA_Array

### DIFF
--- a/R/getFirehoseData.R
+++ b/R/getFirehoseData.R
@@ -604,7 +604,7 @@ getFirehoseData <- function(dataset, runDate=NULL, gistic2_Date=NULL, RNAseq_Gen
                       paste0("-miRNAArray-",listCount,".txt"),
                       TRUE,destdir,forceDownload,runDate)
           tmpReturn <- new("FirehosemRNAArray",Filename=ii,
-                           DataMatrix=.makeExprMat(export.file,"","miRNAArray",100,TRUE,runDate))
+                           DataMatrix=.makeExprMat(export.file,"","miRNAArray",100,TRUE))
           dataLists[[listCount]] <- tmpReturn
           listCount = listCount + 1 
         }


### PR DESCRIPTION
Trying to download miRNAArray data results in an error:

```
> gbm <-getFirehoseData (dataset="GBM", runDate="20150204",
+ Clinic=FALSE, miRNA_Array=TRUE)
gdac.broadinstitute.org_GBM.Merge_mirna__h_mirna_8x15k__unc_edu__Level_3__unc_DWD_Batch_adjusted__data.Level_3.2015020400.0.0.tar.gz
trying URL 'http://gdac.broadinstitute.org/runs/stddata__2015_02_04/data/GBM/20150204/gdac.broadinstitute.org_GBM.Merge_mirna__h_mirna_8x15k__unc_edu__Level_3__unc_DWD_Batch_adjusted__data.Level_3.2015020400.0.0.tar.gz'
Content type 'application/x-gzip' length 2517902 bytes (2.4 MB)
==================================================
downloaded 2.4 MB

gdac.broadinstitute.org_GBM.Merge_mirna__h_mirna_8x15k__unc_edu__Level_3__unc_DWD_Batch_adjusted__data.Level_3.2015020400.0.0
 Error in .makeExprMat(export.file, "", "miRNAArray", 100, TRUE, runDate) : 
```

  unused argument (runDate)

The runDate parameter should not be provided to .makeExprMat

I have tested the modified package and it can load miRNA_Array data.
